### PR TITLE
Fix example python numerical_verification_eprop_hardcoded_vs_autodiff.py in tf1.0

### DIFF
--- a/numerical_verification_eprop_hardcoded_vs_autodiff.py
+++ b/numerical_verification_eprop_hardcoded_vs_autodiff.py
@@ -96,8 +96,8 @@ gradients_eprop, eligibility_traces, _, _ = \
     cell.compute_loss_gradient(learning_signals, pre_synpatic_spike_one_step_before, spikes, voltages,
                                thr_variations, decay_out, True)
 
-# 6. Compute the gradients with BPTT as a ground truth
-gradients_BPTT = tf.gradients(loss, cell.w_rec_var)[0]
+# 6. Compute the gradients with auto-diff as a ground truth (stop_z_gradients=True)
+gradients_autodiff = tf.gradients(loss, cell.w_rec_var)[0]
 
 # 7. Start the tensorflow session to run the computation
 # (until now we only built a computational graph, no simulation has been performed)

--- a/numerical_verification_eprop_hardcoded_vs_autodiff.py
+++ b/numerical_verification_eprop_hardcoded_vs_autodiff.py
@@ -124,16 +124,16 @@ ax_list[1].set_title("Gradient dE/dW_ji with autodiff")
 
 # Compute the relative error:
 g_e_prop = np_tensors['gradients_eprop']
-g_bptt = np_tensors['gradients_autodiff']
-M = np.max(np.abs(g_bptt))
+g_autodiff = np_tensors['gradients_autodiff']
+M = np.max(np.abs(g_autodiff))
 
 print("Max abs value of the true gradient: ", M)
-assert (not np.any(np.isnan(g_bptt)), "The auto-diff has NaN coeffs, this not a very interesting verification.")
+assert (not np.any(np.isnan(g_autodiff)), "The auto-diff has NaN coeffs, this not a very interesting verification.")
 assert M != 0, "The auto-diff gradient is zero, this not a very interesting verification."
 g_e_prop /= M
-g_bptt /= M
+g_autodiff /= M
 
-gradient_errors = (g_e_prop - g_bptt) ** 2
+gradient_errors = (g_e_prop - g_autodiff) ** 2
 max_gradient_errors = np.max(gradient_errors)
 print("Gradients computed with symmetric e-prop:")
 print(np.array_str(np_tensors['gradients_eprop'], precision=5, suppress_small=True))


### PR DESCRIPTION
Variable 'gradients_autodiff' not declared without this fix in numerical_verification_eprop_hardcoded_vs_autodiff.py

Also, I did a few changes in the existing code to be able to run the autodiff check, using the tf2 compatibility module. Code can be found here: https://github.com/florian6973/btt-spyx